### PR TITLE
Add support for alternative scenes to sample app

### DIFF
--- a/src/Testing.cpp
+++ b/src/Testing.cpp
@@ -173,6 +173,7 @@ void ProcessCommandLine(int argc, char** argv, donut::app::DeviceCreationParamet
         ("render-height", "Internal render target height, overrides window size", value(args.renderHeight))
         ("save-file", "Save frame to file and exit", value(args.saveFrameFileName))
         ("save-frame", "Index of the frame to save, default is 0", value(args.saveFrameIndex))
+        ("scene-file", "Name of the scene file in the 'media' folder", value(args.sceneFile))
         ("tone-mapping", "Tone mapping toggle", value(ui.enableToneMapping))
         ("transparent", "Transparent materials toggle", value(ui.gbufferSettings.enableTransparentGeometry))
         ("verbose", "Enable debug log messages", value(args.verbose))

--- a/src/Testing.h
+++ b/src/Testing.h
@@ -34,6 +34,7 @@ struct CommandLineArguments
     bool disableBackgroundOptimization = false;
     int renderWidth = 0;
     int renderHeight = 0;
+    std::string sceneFile = "bistro-rtxdi.scene.json";
 };
 
 void ProcessCommandLine(int argc, char** argv, donut::app::DeviceCreationParameters& deviceParams, UIData& ui, CommandLineArguments& args);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,7 +212,7 @@ public:
             m_BindlessLayout = GetDevice()->createBindlessLayout(bindlessLayoutDesc);
         }
 
-        std::filesystem::path scenePath = "/media/bistro-rtxdi.scene.json";
+        std::filesystem::path scenePath = "/media/" + m_args.sceneFile;
 
         m_DescriptorTableManager = std::make_shared<engine::DescriptorTableManager>(GetDevice(), m_BindlessLayout);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -314,10 +314,27 @@ public:
 
         m_Scene->FinishedLoading(GetFrameIndex());
 
-        m_Camera.LookAt(float3(-7.688f, 2.0f, 5.594f), float3(-7.3341f, 2.0f, 6.5366f));
-        m_Camera.SetMoveSpeed(3.f);
-
         const auto& sceneGraph = m_Scene->GetSceneGraph();
+        const auto& cameras = sceneGraph->GetCameras();
+
+        if (!cameras.empty())
+        {
+            const std::shared_ptr<engine::SceneCamera>& glTfCam = cameras[0];
+
+            auto camPos = glTfCam->GetViewToWorldMatrix().transformPoint(dm::float3(0.0f));
+            auto camTarget = glTfCam->GetViewToWorldMatrix().transformPoint(dm::float3(0.0f, 0.0f, 1.0f));
+            m_Camera.LookAt(camPos, camTarget);
+
+            if (auto glTFPerspectiveCam = std::static_pointer_cast<engine::PerspectiveCamera>(glTfCam); glTFPerspectiveCam)
+            {
+                m_ui.verticalFov = dm::degrees(glTFPerspectiveCam->verticalFov);
+            }
+        }
+        else
+        {
+            m_Camera.LookAt(float3(-7.688f, 2.0f, 5.594f), float3(-7.3341f, 2.0f, 6.5366f));
+        }
+        m_Camera.SetMoveSpeed(3.f);
 
         for (const auto& pLight : sceneGraph->GetLights())
         {


### PR DESCRIPTION
This PR adds a command line arg which can be used to test alternative scenes in order to evaluate the RTXDI SDK. Additionally, after the scene is loaded, we switch to an appropriate camera, if specified in the glTF file.