### PR TITLE
Fix spot lights imported from glTF files.

### DIFF
--- a/src/PrepareLightsPass.cpp
+++ b/src/PrepareLightsPass.cpp
@@ -208,8 +208,9 @@ static bool ConvertLight(const donut::engine::Light& light, PolymorphicLightInfo
         polymorphic.scalars = fp32ToFp16(halfAngularSizeRad) | (fp32ToFp16(solidAngle) << 16);
         return true;
     }
-    case LightType_Spot: {
-        auto& spot = static_cast<const SpotLightWithProfile&>(light);
+    case LightType_Spot:
+    case LightType_SpotProfile: {
+        auto& spot = static_cast<const SpotLight&>(light);
         if (spot.radius == 0.f)
         {
             float3 flux = spot.color * spot.intensity;
@@ -236,10 +237,14 @@ static bool ConvertLight(const donut::engine::Light& light, PolymorphicLightInfo
         polymorphic.cosConeAngleAndSoftness = fp32ToFp16(cosf(dm::radians(spot.outerAngle)));
         polymorphic.cosConeAngleAndSoftness |= fp32ToFp16(softness) << 16;
 
-        if (spot.profileTextureIndex >= 0)
+        if (spot.GetLightType() == LightType_SpotProfile)
         {
-            polymorphic.iesProfileIndex = spot.profileTextureIndex;
-            polymorphic.colorTypeAndFlags |= kPolymorphicLightIesProfileEnableBit;
+            auto& spotWithProfile = static_cast<const SpotLightWithProfile&>(light);
+            if (spotWithProfile.profileTextureIndex >= 0)
+            {
+                polymorphic.iesProfileIndex = spotWithProfile.profileTextureIndex;
+                polymorphic.colorTypeAndFlags |= kPolymorphicLightIesProfileEnableBit;
+            }
         }
 
         return true;

--- a/src/SampleScene.h
+++ b/src/SampleScene.h
@@ -17,6 +17,7 @@ constexpr int LightType_Environment = 1000;
 constexpr int LightType_Cylinder = 1001;
 constexpr int LightType_Disk = 1002;
 constexpr int LightType_Rect = 1003;
+constexpr int LightType_SpotProfile = 1004;
 
 class SpotLightWithProfile : public donut::engine::SpotLight
 {
@@ -26,6 +27,7 @@ public:
 
     void Load(const Json::Value& node) override;
     void Store(Json::Value& node) const override;
+    [[nodiscard]] int GetLightType() const override { return LightType_SpotProfile; }
     [[nodiscard]] std::shared_ptr<SceneGraphLeaf> Clone() override;
 };
 

--- a/src/UserInterface.cpp
+++ b/src/UserInterface.cpp
@@ -1121,38 +1121,43 @@ void UserInterface::SceneSettings()
                 break;
             }
             case LightType_Spot:
+            case LightType_SpotProfile:
             {
-                SpotLightWithProfile& spotLight = static_cast<SpotLightWithProfile&>(*m_SelectedLight);
+                engine::SpotLight& spotLight = static_cast<engine::SpotLight&>(*m_SelectedLight);
                 app::LightEditor_Spot(spotLight);
 
-                ImGui::PushItemWidth(150.f);
-                if (ImGui::BeginCombo("IES Profile", spotLight.profileName.empty() ? "(none)" : spotLight.profileName.c_str()))
+                if (spotLight.GetLightType() == LightType_SpotProfile)
                 {
-                    bool selected = spotLight.profileName.empty();
-                    if (ImGui::Selectable("(none)", &selected) && selected)
+                    SpotLightWithProfile& spotLightProfile = static_cast<SpotLightWithProfile&>(*m_SelectedLight);
+                    ImGui::PushItemWidth(150.f);
+                    if (ImGui::BeginCombo("IES Profile", spotLightProfile.profileName.empty() ? "(none)" : spotLightProfile.profileName.c_str()))
                     {
-                        spotLight.profileName = "";
-                        spotLight.profileTextureIndex = -1;
-                    }
-
-                    for (auto profile : m_ui.resources->iesProfiles)
-                    {
-                        selected = profile->name == spotLight.profileName;
-                        if (ImGui::Selectable(profile->name.c_str(), &selected) && selected)
+                        bool selected = spotLightProfile.profileName.empty();
+                        if (ImGui::Selectable("(none)", &selected) && selected)
                         {
-                            spotLight.profileName = profile->name;
-                            spotLight.profileTextureIndex = -1;
+                            spotLightProfile.profileName = "";
+                            spotLightProfile.profileTextureIndex = -1;
                         }
 
-                        if (selected)
+                        for (auto profile : m_ui.resources->iesProfiles)
                         {
-                            ImGui::SetItemDefaultFocus();
-                        }
-                    }
+                            selected = profile->name == spotLightProfile.profileName;
+                            if (ImGui::Selectable(profile->name.c_str(), &selected) && selected)
+                            {
+                                spotLightProfile.profileName = profile->name;
+                                spotLightProfile.profileTextureIndex = -1;
+                            }
 
-                    ImGui::EndCombo();
+                            if (selected)
+                            {
+                                ImGui::SetItemDefaultFocus();
+                            }
+                        }
+
+                        ImGui::EndCombo();
+                    }
+                    ImGui::PopItemWidth();
                 }
-                ImGui::PopItemWidth();
 
                 if (ImGui::Button("Place Here"))
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -285,7 +285,7 @@ public:
     {
         for (const auto& light : m_Scene->GetSceneGraph()->GetLights())
         {
-            if (light->GetLightType() == LightType_Spot)
+            if (light->GetLightType() == LightType_SpotProfile)
             {
                 SpotLightWithProfile& spotLight = static_cast<SpotLightWithProfile&>(*light);
 


### PR DESCRIPTION
Spot lights currently only work correctly if they have a non-zero radius. When exported from glTF they always have a radius of `0.0f` (non-point shapes are not supported there).
This PR adds some code to correctly handle spot lights with zero radius (similar to point lights with zero radius).